### PR TITLE
Update to latest version of git

### DIFF
--- a/ubuntu-base/Dockerfile
+++ b/ubuntu-base/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     wget && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+    add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \
     ca-certificates \


### PR DESCRIPTION
GitHub's actions/checkout requires git version 2.18 or later. we currently have 2.17 installed. The associated issue is here: https://github.com/actions/checkout/issues/126