### PR TITLE
Publish support for GitHub Container registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,18 @@ jobs:
       - uses: actions/checkout@v2
       - run: make UBUNTU=20.04 update
       - run: make UBUNTU=20.04 build
-      - run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          make UBUNTU=20.04 push
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        if: ${{ github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main' }} 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: ${{ github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main' }} 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: make UBUNTU=20.04 push
         if: ${{ github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main' }} 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,19 @@
 UBUNTU?=20.04
 
+IMAGES = \
+	ubuntu-base:${UBUNTU} \
+	roborio-cross-ubuntu:2022-${UBUNTU} \
+	raspbian-cross-ubuntu:10-${UBUNTU} \
+	aarch64-cross-ubuntu:bionic-${UBUNTU} \
+	gazebo-ubuntu:${UBUNTU}
+
 usage:
-	@echo "Run make update, make build, and make push"
+	@echo "Usage: make [command]"
+	@echo "Commands:"
+	@echo "	update"
+	@echo "	build"
+	@echo "	tag"
+	@echo "	push"
 
 update:
 	docker pull ubuntu:${UBUNTU}
@@ -16,9 +28,14 @@ build:
 	    docker build -t wpilib/aarch64-cross-ubuntu:bionic-${UBUNTU} -f Dockerfile.bionic --build-arg UBUNTU=${UBUNTU} .
 	cd gazebo-ubuntu && docker build -t wpilib/gazebo-ubuntu:${UBUNTU} --build-arg UBUNTU=${UBUNTU} .
 
+tag:
+	for i in $(IMAGES); do \
+		docker tag wpilib/$$i docker.io/wpilib/$$i || exit; \
+		docker tag wpilib/$$i ghcr.io/wpilib/$$i || exit; \
+	done
+
 push:
-	docker push wpilib/ubuntu-base:${UBUNTU}
-	docker push wpilib/roborio-cross-ubuntu:2022-${UBUNTU}
-	docker push wpilib/raspbian-cross-ubuntu:10-${UBUNTU}
-	docker push wpilib/aarch64-cross-ubuntu:bionic-${UBUNTU}
-	docker push wpilib/gazebo-ubuntu:${UBUNTU}
+	for i in $(IMAGES); do \
+		docker push docker.io/wpilib/$$i || exit; \
+		docker push ghcr.io/wpilib/$$i || exit; \
+	done


### PR DESCRIPTION
For users who are publishing, you will need to follow the steps as shown [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).