### PR TITLE
Explicitly set roborio platform tag for crossenv

### DIFF
--- a/cross-ubuntu-py/Dockerfile.py310
+++ b/cross-ubuntu-py/Dockerfile.py310
@@ -84,11 +84,12 @@ COPY --from=pycompile /build/crosspy /build/crosspy
 
 ARG ARCH=invalid-arch
 ARG TARGET_HOST=invalid-target-host
+ARG EXTRA_CROSSENV_ARGS=
 
 RUN set -xe; \
     ldconfig; \
-    python3.10 -m pip install crossenv==1.4.0; \
-    python3.10 -m crossenv /build/crosspy/bin/python3.10 /build/venv --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc; \
+    python3.10 -m pip install crossenv==1.5.0; \
+    python3.10 -m crossenv /build/crosspy/bin/python3.10 /build/venv --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc ${EXTRA_CROSSENV_ARGS}; \
     /build/venv/bin/cross-pip install wheel;
 
 COPY pip-${ARCH}.conf /build/venv/cross/pip.conf

--- a/cross-ubuntu-py/Dockerfile.py311
+++ b/cross-ubuntu-py/Dockerfile.py311
@@ -88,11 +88,12 @@ COPY --from=pycompile /build/crosspy /build/crosspy
 
 ARG ARCH=invalid-arch
 ARG TARGET_HOST=invalid-target-host
+ARG EXTRA_CROSSENV_ARGS=
 
 RUN set -xe; \
     ldconfig; \
-    python3.11 -m pip install crossenv==1.4.0; \
-    python3.11 -m crossenv /build/crosspy/bin/python3.11 /build/venv --sysroot=$(${TARGET_HOST}-print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc; \
+    python3.11 -m pip install crossenv==1.5.0; \
+    python3.11 -m crossenv /build/crosspy/bin/python3.11 /build/venv --sysroot=$(${TARGET_HOST}-print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc ${EXTRA_CROSSENV_ARGS}; \
     /build/venv/bin/cross-pip install wheel;
 
 COPY pip-${ARCH}.conf /build/venv/cross/pip.conf

--- a/cross-ubuntu-py/Dockerfile.py312
+++ b/cross-ubuntu-py/Dockerfile.py312
@@ -94,11 +94,12 @@ COPY --from=pycompile /build/crosspy /build/crosspy
 ARG ARCH=invalid-arch
 ARG TARGET_HOST=invalid-target-host
 ARG MACHINE_ARG=
+ARG EXTRA_CROSSENV_ARGS=
 
 RUN set -xe; \
     ldconfig; \
-    python3.12 -m pip install 'crossenv~=1.4.0'; \
-    python3.12 -m crossenv /build/crosspy/bin/python3.12 /build/venv ${MACHINE_ARG} --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc; \
+    python3.12 -m pip install 'crossenv~=1.5.0'; \
+    python3.12 -m crossenv /build/crosspy/bin/python3.12 /build/venv ${MACHINE_ARG} --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc ${EXTRA_CROSSENV_ARGS}; \
     /build/venv/bin/cross-pip install wheel;
 
 COPY pip-${ARCH}.conf /build/venv/cross/pip.conf

--- a/cross-ubuntu-py/Dockerfile.py313
+++ b/cross-ubuntu-py/Dockerfile.py313
@@ -96,11 +96,12 @@ COPY --from=pycompile /build/crosspy /build/crosspy
 ARG ARCH=invalid-arch
 ARG TARGET_HOST=invalid-target-host
 ARG MACHINE_ARG=
+ARG EXTRA_CROSSENV_ARGS=
 
 RUN set -xe; \
     ldconfig; \
     python3.13 -m pip install 'crossenv~=1.5.0'; \
-    python3.13 -m crossenv /build/crosspy/bin/python3.13 /build/venv ${MACHINE_ARG} --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc; \
+    python3.13 -m crossenv /build/crosspy/bin/python3.13 /build/venv ${MACHINE_ARG} --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc ${EXTRA_CROSSENV_ARGS}; \
     /build/venv/bin/cross-pip install wheel;
 
 COPY pip-${ARCH}.conf /build/venv/cross/pip.conf

--- a/cross-ubuntu-py/Dockerfile.py39
+++ b/cross-ubuntu-py/Dockerfile.py39
@@ -83,11 +83,12 @@ COPY --from=pycompile /build/crosspy /build/crosspy
 
 ARG ARCH=invalid-arch
 ARG TARGET_HOST=invalid-target-host
+ARG EXTRA_CROSSENV_ARGS=
 
 RUN set -xe; \
     ldconfig; \
-    python3.9 -m pip install crossenv==1.4.0; \
-    python3.9 -m crossenv /build/crosspy/bin/python3.9 /build/venv --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc; \
+    python3.9 -m pip install crossenv==1.5.0; \
+    python3.9 -m crossenv /build/crosspy/bin/python3.9 /build/venv --sysroot=$(${TARGET_HOST}-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc ${EXTRA_CROSSENV_ARGS}; \
     /build/venv/bin/cross-pip install wheel;
 
 COPY pip-${ARCH}.conf /build/venv/cross/pip.conf

--- a/cross-ubuntu-py/py.mk
+++ b/cross-ubuntu-py/py.mk
@@ -204,6 +204,7 @@ build/cross-roborio-py313:
 		--build-arg AC_TARGET_HOST=$(AC_TARGET_HOST_ROBORIO) \
 		--build-arg VERSION=$(VERSION_ROBORIO) \
 		--build-arg MACHINE_ARG="--machine=roborio" \
+		--build-arg EXTRA_CROSSENV_ARGS="--platform-tag=linux_roborio" \
 		-f Dockerfile.py313
 
 .PHONY: push/cross-roborio-py313


### PR DESCRIPTION
Fixes errors in should_build.py that cause failures in roborio-wheels (https://github.com/robotpy/roborio-wheels/actions/runs/11977999266)