### PR TITLE
Add systemcore images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ build/base:
 build/cross: build/base
 	cd roborio-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/roborio-cross-ubuntu:2024-${UBUNTU} -f Dockerfile.2024 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
+	cd systemcore-cross-ubuntu && \
+	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
 	cd raspbian-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/raspbian-cross-ubuntu:bullseye-${UBUNTU} -f Dockerfile.bullseye --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
 	cd aarch64-cross-ubuntu && \
@@ -36,6 +38,8 @@ build/minimal-base:
 build/minimal-cross: build/minimal-base
 	cd roborio-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2024-${UBUNTU} -f Dockerfile.2024 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
+	cd systemcore-cross-ubuntu && \
+	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
 	cd raspbian-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bullseye-${UBUNTU} -f Dockerfile.bullseye --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
 	cd aarch64-cross-ubuntu && \
@@ -53,6 +57,7 @@ push/base:
 
 push/cross: push/base
 	docker push ${DOCKER_USER}/roborio-cross-ubuntu:2024-${UBUNTU}
+	docker push ${DOCKER_USER}/systemcore-cross-ubuntu:2025-${UBUNTU}
 	docker push ${DOCKER_USER}/raspbian-cross-ubuntu:bullseye-${UBUNTU}
 	docker push ${DOCKER_USER}/aarch64-cross-ubuntu:bullseye-${UBUNTU}
 
@@ -61,6 +66,7 @@ push/minimal-base:
 
 push/minimal-cross: push/minimal-base
 	docker push ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2024-${UBUNTU}
+	docker push ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU}
 	docker push ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bullseye-${UBUNTU}
 	docker push ${DOCKER_USER}/aarch64-cross-ubuntu-minimal:bullseye-${UBUNTU}
 
@@ -71,6 +77,7 @@ push/opensdk:
 .PHONY: save/minimal-cross
 save/minimal-cross:
 	docker save ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2024-${UBUNTU} | gzip > roborio.tar.gz
+	docker save ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU} | gzip > systemcore.tar.gz
 	docker save ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bullseye-${UBUNTU} | gzip > raspbian.tar.gz
 	docker save ${DOCKER_USER}/aarch64-cross-ubuntu-minimal:bullseye-${UBUNTU} | gzip > aarch64.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ roborio-cross-ubuntu
    (e.g. 2020-18.04)
  - Minimal variant published as roborio-cross-ubuntu-minimal
 
+systemcore-cross-ubuntu
+ - Based on wpilib/ubuntu-base
+ - Cross-compiler for systemcore (Bookworm for now)
+ - Published as wpilib/systemcore-cross-ubuntu:frc season-host ubuntu version
+   (e.g. 2020-18.04)
+ - Minimal variant published as systemcore-cross-ubuntu-minimal
+
 raspbian-cross-ubuntu
  - Based on wpilib/ubuntu-base
  - Cross-compiler for Raspbian

--- a/systemcore-cross-ubuntu/Dockerfile.2025
+++ b/systemcore-cross-ubuntu/Dockerfile.2025
@@ -1,0 +1,8 @@
+ARG UBUNTU=22.04
+ARG TYPE=base
+FROM wpilib/ubuntu-${TYPE}:${UBUNTU}
+
+# Install toolchain
+RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz | sh -c 'mkdir -p /usr/local && cd /usr/local && tar xzf - --strip-components=2'
+
+WORKDIR /


### PR DESCRIPTION
For now, just uses the bookworm compiler. Once we get a specific systemcore compiler, we'll move the compiler to it.