### PR TITLE
Install libopencv-java in base images

### DIFF
--- a/debian-base/Dockerfile.bookworm
+++ b/debian-base/Dockerfile.bookworm
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     libglu1-mesa-dev \
     libisl-dev \
     libopencv-dev \
+    libopencv-java \
     libvulkan-dev \
     libx11-dev \
     libxcursor-dev \

--- a/ubuntu-base/Dockerfile.22.04
+++ b/ubuntu-base/Dockerfile.22.04
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     libglu1-mesa-dev \
     libisl-dev \
     libopencv-dev \
+    libopencv4.5-java \
     libvulkan-dev \
     libx11-dev \
     libxcursor-dev \

--- a/ubuntu-base/Dockerfile.24.04
+++ b/ubuntu-base/Dockerfile.24.04
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     libglu1-mesa-dev \
     libisl-dev \
     libopencv-dev \
+    libopencv-java \
     libvulkan-dev \
     libx11-dev \
     libxcursor-dev \


### PR DESCRIPTION
Ubuntu 22.04 is the odd one out including the OpenCV version number in the package name.

To avoid requiring conditional logic downstream on the distro version, install it into the base image.