### PR TITLE
Avoid trusting kitware keys globally

### DIFF
--- a/ubuntu-base/Dockerfile.22.04
+++ b/ubuntu-base/Dockerfile.22.04
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     software-properties-common \
     wget && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
-    apt-add-repository 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' > /etc/apt/sources.list.d/kitware.list && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \

--- a/ubuntu-base/Dockerfile.22.04
+++ b/ubuntu-base/Dockerfile.22.04
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     gnupg \
     software-properties-common \
     wget && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main' && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    apt-add-repository 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \

--- a/ubuntu-base/Dockerfile.24.04
+++ b/ubuntu-base/Dockerfile.24.04
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     gnupg \
     software-properties-common \
     wget && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ noble main' && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    apt-add-repository 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \

--- a/ubuntu-base/Dockerfile.24.04
+++ b/ubuntu-base/Dockerfile.24.04
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     software-properties-common \
     wget && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
-    apt-add-repository 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' > /etc/apt/sources.list.d/kitware.list && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \


### PR DESCRIPTION
Per instructions at https://apt.kitware.com/