### PR TITLE
Make 2027 systemcore images with JDK 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,12 @@ jobs:
           name: raspbian-${{ matrix.ubuntu-version }}
           path: raspbian.tar.gz
           retention-days: 1
+      - name: Upload systemcore cross base image
+        uses: actions/upload-artifact@v4
+        with:
+          name: systemcore-${{ matrix.ubuntu-version }}
+          path: systemcore.tar.gz
+          retention-days: 1
 
   build-python:
     name: Build Python Images

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build/cross: build/base
 	cd roborio-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/roborio-cross-ubuntu:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
 	cd systemcore-cross-ubuntu && \
-	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
+	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu:2027-${UBUNTU} -f Dockerfile.2027 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
 	cd raspbian-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/raspbian-cross-ubuntu:bookworm-${UBUNTU} -f Dockerfile.bookworm --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=base .
 	cd aarch64-cross-ubuntu && \
@@ -45,7 +45,7 @@ build/minimal-cross: build/minimal-base
 	cd roborio-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
 	cd systemcore-cross-ubuntu && \
-	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU} -f Dockerfile.2025 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
+	    docker build -t ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2027-${UBUNTU} -f Dockerfile.2027 --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
 	cd raspbian-cross-ubuntu && \
 	    docker build -t ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bookworm-${UBUNTU} -f Dockerfile.bookworm --build-arg UBUNTU=${UBUNTU} --build-arg TYPE=minimal-base .
 	cd aarch64-cross-ubuntu && \
@@ -65,7 +65,7 @@ push/base:
 
 push/cross: push/base
 	docker push ${DOCKER_USER}/roborio-cross-ubuntu:2025-${UBUNTU}
-	docker push ${DOCKER_USER}/systemcore-cross-ubuntu:2025-${UBUNTU}
+	docker push ${DOCKER_USER}/systemcore-cross-ubuntu:2027-${UBUNTU}
 	docker push ${DOCKER_USER}/raspbian-cross-ubuntu:bookworm-${UBUNTU}
 	docker push ${DOCKER_USER}/aarch64-cross-ubuntu:bookworm-${UBUNTU}
 
@@ -74,7 +74,7 @@ push/minimal-base:
 
 push/minimal-cross: push/minimal-base
 	docker push ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2025-${UBUNTU}
-	docker push ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU}
+	docker push ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2027-${UBUNTU}
 	docker push ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bookworm-${UBUNTU}
 	docker push ${DOCKER_USER}/aarch64-cross-ubuntu-minimal:bookworm-${UBUNTU}
 
@@ -85,7 +85,7 @@ push/opensdk:
 .PHONY: save/minimal-cross
 save/minimal-cross:
 	docker save ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2025-${UBUNTU} | gzip > roborio.tar.gz
-	docker save ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2025-${UBUNTU} | gzip > systemcore.tar.gz
+	docker save ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2027-${UBUNTU} | gzip > systemcore.tar.gz
 	docker save ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bookworm-${UBUNTU} | gzip > raspbian.tar.gz
 	docker save ${DOCKER_USER}/aarch64-cross-ubuntu-minimal:bookworm-${UBUNTU} | gzip > aarch64.tar.gz
 

--- a/debian-base/Dockerfile.bookworm
+++ b/debian-base/Dockerfile.bookworm
@@ -31,16 +31,20 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     libxrandr-dev \
     make \
     mesa-common-dev \
-    openjdk-17-jdk \
     python3-dev \
     python3-pip \
     python3-setuptools \
     sudo \
     unzip \
     wget \
-    zip \
-  && rm -rf /var/lib/apt/lists/*
+    zip
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-arm64
+RUN curl https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+
+RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+
+RUN apt update && apt install -y temurin-21-jdk && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/temurin-21-jdk-arm64
 
 WORKDIR /

--- a/systemcore-cross-ubuntu/Dockerfile.2025
+++ b/systemcore-cross-ubuntu/Dockerfile.2025
@@ -1,8 +1,0 @@
-ARG UBUNTU=22.04
-ARG TYPE=base
-FROM wpilib/ubuntu-${TYPE}:${UBUNTU}
-
-# Install toolchain
-RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz | sh -c 'mkdir -p /usr/local && cd /usr/local && tar xzf - --strip-components=2'
-
-WORKDIR /

--- a/systemcore-cross-ubuntu/Dockerfile.2027
+++ b/systemcore-cross-ubuntu/Dockerfile.2027
@@ -1,0 +1,12 @@
+ARG UBUNTU=22.04
+ARG TYPE=base
+FROM wpilib/ubuntu-${TYPE}:${UBUNTU}
+
+# Install toolchain
+RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-2/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz | sh -c 'mkdir -p /usr/local && cd /usr/local && tar xzf - --strip-components=2'
+
+RUN apt update && apt install -y openjdk-21-jdk && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-amd64
+
+WORKDIR /


### PR DESCRIPTION
Uses Adoptium JDK for bookworm. Updates arm bookworm directly since it doesn't seem to be currently used. 
Supersedes #42