### PR TITLE
zstd saved image artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Load image
       run: |
-        gunzip -c img/${{ matrix.type }}.tar.gz | docker load
+        unzstd -c img/${{ matrix.type }}.tar.gz | docker load
         rm img/${{ matrix.type }}.tar.gz
 
     - name: Build image

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ push/opensdk:
 
 .PHONY: save/minimal-cross
 save/minimal-cross:
-	docker save ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2025-${UBUNTU} | gzip > roborio.tar.gz
-	docker save ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2027-${UBUNTU} | gzip > systemcore.tar.gz
-	docker save ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bookworm-${UBUNTU} | gzip > raspbian.tar.gz
+	docker save ${DOCKER_USER}/roborio-cross-ubuntu-minimal:2025-${UBUNTU} | zstd > roborio.tar.gz
+	docker save ${DOCKER_USER}/systemcore-cross-ubuntu-minimal:2027-${UBUNTU} | zstd > systemcore.tar.gz
+	docker save ${DOCKER_USER}/raspbian-cross-ubuntu-minimal:bookworm-${UBUNTU} | zstd > raspbian.tar.gz
 
 include cross-ubuntu-py/py.mk


### PR DESCRIPTION
Zstandard is both significantly faster and has better compression ratios than gzip for our OCI images. This saves about 3.5 minutes just on compressing the tarballs.