### PR TITLE
Build ubuntu 24.04-based systemcore python image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
           ubuntu-version: 22.04
         - type: systemcore
           pyversion: py313
-          ubuntu-version: 22.04
+          ubuntu-version: 24.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We build with the 24.04 image in allwpilib for the 2027 branch, we should do the same for robotpy. cc @virtuald

https://github.com/wpilibsuite/allwpilib/blob/412d18950725753c9294e336e05cb4b7d575fab4/.github/workflows/gradle.yml#L22