### PR TITLE
Fix use of legacy ENV format

### DIFF
--- a/aarch64-cross-ubuntu/Dockerfile.bookworm-2027
+++ b/aarch64-cross-ubuntu/Dockerfile.bookworm-2027
@@ -7,6 +7,6 @@ RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-2/ar
 
 RUN apt update && apt install -y openjdk-21-jdk && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 WORKDIR /

--- a/debian-base/Dockerfile.bookworm
+++ b/debian-base/Dockerfile.bookworm
@@ -45,6 +45,6 @@ RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION
 
 RUN apt update && apt install -y temurin-21-jdk && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/temurin-21-jdk-arm64
+ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-arm64
 
 WORKDIR /

--- a/raspbian-cross-ubuntu/Dockerfile.bookworm-2027
+++ b/raspbian-cross-ubuntu/Dockerfile.bookworm-2027
@@ -8,6 +8,6 @@ RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-2/ar
 
 RUN apt update && apt install -y openjdk-21-jdk && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 WORKDIR /

--- a/systemcore-cross-ubuntu/Dockerfile.2027
+++ b/systemcore-cross-ubuntu/Dockerfile.2027
@@ -7,6 +7,6 @@ RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-2/ar
 
 RUN apt update && apt install -y openjdk-21-jdk && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 WORKDIR /

--- a/ubuntu-base/Dockerfile.22.04
+++ b/ubuntu-base/Dockerfile.22.04
@@ -46,6 +46,6 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 WORKDIR /

--- a/ubuntu-base/Dockerfile.24.04
+++ b/ubuntu-base/Dockerfile.24.04
@@ -45,6 +45,6 @@ RUN apt-get update && apt-get install -y apt-transport-https \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 WORKDIR /


### PR DESCRIPTION
https://github.com/wpilibsuite/docker-images/actions/runs/17523593845/job/49772859499#step:4:11