### PR TITLE
Add avahi-daemon to systemcore-cross-ubuntu

### DIFF
--- a/systemcore-cross-ubuntu/Dockerfile.2027
+++ b/systemcore-cross-ubuntu/Dockerfile.2027
@@ -5,7 +5,7 @@ FROM wpilib/ubuntu-${TYPE}:${UBUNTU}
 # Install toolchain
 RUN curl -SL https://github.com/wpilibsuite/opensdk/releases/download/v2025-2/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz | sh -c 'mkdir -p /usr/local && cd /usr/local && tar xzf - --strip-components=2'
 
-RUN apt update && apt install -y openjdk-21-jdk && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y openjdk-21-jdk avahi-daemon && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 


### PR DESCRIPTION
In https://github.com/wpilibsuite/allwpilib/pull/8682#discussion_r2963985123 we decided that we should add avahi-daemon to the systemcore-cross-ubuntu container. This container is used in our Gradle non-cross builds, which build and run linux x86 tests. To exercise our MDNS responder in unit tests on Linux, we need avahi-daemon installed